### PR TITLE
Fixed missing marking points for Humans & Vulpkanins

### DIFF
--- a/Resources/Prototypes/DeltaV/Species/vulpkanin.yml
+++ b/Resources/Prototypes/DeltaV/Species/vulpkanin.yml
@@ -45,20 +45,23 @@
     FacialHair:
       points: 1
       required: false
-    Tail:
+    Face:
+      points: 6
+      required: false
+    Head:
+      points: 2
+      required: false
+    HeadTop:
       points: 1
       required: true
-      defaultMarkings: [ VulpTail ]
-    RightLeg:
-      points: 6
+      defaultMarkings: [ VulpEar ]
+    HeadSide:
+      points: 4
       required: false
-    RightFoot:
-      points: 6
+    Snout:
+      points: 1
       required: false
-    LeftLeg:
-      points: 6
-      required: false
-    LeftFoot:
+    Chest:
       points: 6
       required: false
     RightArm:
@@ -73,16 +76,28 @@
     LeftHand:
       points: 6
       required: false
-    Snout:
-      points: 1
-      required: false
-    HeadTop:
-      points: 1
-      required: true
-      defaultMarkings: [ VulpEar ]
-    HeadSide:
+    RightLeg:
       points: 6
       required: false
+    RightFoot:
+      points: 6
+      required: false
+    LeftLeg:
+      points: 6
+      required: false
+    LeftFoot:
+      points: 6
+      required: false
+    Underwear:
+      points: 1
+      required: false
+    Undershirt:
+      points: 1
+      required: false
+    Tail:
+      points: 1
+      required: true
+      defaultMarkings: [ VulpTail ]
 
 - type: humanoidBaseSprite
   id: MobVulpkaninHead

--- a/Resources/Prototypes/Species/human.yml
+++ b/Resources/Prototypes/Species/human.yml
@@ -43,20 +43,17 @@
 - type: markingPoints
   id: MobHumanMarkingLimits
   points:
-    Head:
-      points: 2
-      required: false
     Hair:
       points: 1
       required: false
     FacialHair:
       points: 1
       required: false
-    Snout:
-      points: 1
+    Face:
+      points: 6
       required: false
-    Tail:
-      points: 1
+    Head:
+      points: 2
       required: false
     HeadTop:
       points: 1
@@ -64,25 +61,10 @@
     HeadSide:
       points: 4
       required: false
+    Snout:
+      points: 1
+      required: false
     Chest:
-      points: 6
-      required: false
-    Underwear:
-      points: 1
-      required: false
-    Undershirt:
-      points: 1
-      required: false
-    RightLeg:
-      points: 6
-      required: false
-    RightFoot:
-      points: 6
-      required: false
-    LeftLeg:
-      points: 6
-      required: false
-    LeftFoot:
       points: 6
       required: false
     RightArm:
@@ -96,6 +78,27 @@
       required: false
     LeftHand:
       points: 6
+      required: false
+    RightLeg:
+      points: 6
+      required: false
+    RightFoot:
+      points: 6
+      required: false
+    LeftLeg:
+      points: 6
+      required: false
+    LeftFoot:
+      points: 6
+      required: false
+    Underwear:
+      points: 1
+      required: false
+    Undershirt:
+      points: 1
+      required: false
+    Tail:
+      points: 1
       required: false
 
 - type: humanoidBaseSprite


### PR DESCRIPTION
# Reorganization & Missing Marking Points
I have reordered the marking points for humans & vulpkanins, as the previous organization was a mess (Matched it more to the ingame customization options and how they are ordered)

Ontop of that, I added a bunch of missing marking points for vulpkanins and one that was missing from humans (Face)

# Changelog

:cl:
- tweak: Organized marking points for Vulpkanin.yml & Human.yml.
- fix: Added missing marking points for Vulpkanin.yml & Human.yml.
