### PR TITLE
EE Parity Update

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,6 @@
             "fileMatch": [ "**/meta.json" ],
             "url": "https://raw.githubusercontent.com/Simple-Station/Einstein-Engines/master/.github/rsi-schema.json"
         }
-    ]
+    ],
+    "dotnet.preferCSharpExtension": true
 }

--- a/Content.Server/Power/Components/ApcPowerReceiverComponent.cs
+++ b/Content.Server/Power/Components/ApcPowerReceiverComponent.cs
@@ -15,8 +15,24 @@ namespace Content.Server.Power.Components
         ///     Amount of charge this needs from an APC per second to function.
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
+
+        private float _mainLoad = 5;
+        private float _sideLoad;
+        
         [DataField("powerLoad")]
-        public float Load { get => NetworkLoad.DesiredPower; set => NetworkLoad.DesiredPower = value; }
+        public float Load { get => _mainLoad;
+            set { _mainLoad = value; NetworkLoad.DesiredPower = _mainLoad + _sideLoad; }
+            }
+
+        [DataField("sidePowerLoad")]
+        public float SideLoad
+        {
+            get => _sideLoad;
+            set { _sideLoad = value; NetworkLoad.DesiredPower = _mainLoad + _sideLoad; }
+        }
+
+        [ViewVariables(VVAccess.ReadOnly)]
+        public float FullLoad => _mainLoad + _sideLoad;
 
         public ApcPowerProviderComponent? Provider = null;
 
@@ -58,5 +74,11 @@ namespace Content.Server.Power.Components
         };
 
         public float PowerReceived => NetworkLoad.ReceivingPower;
+
+
+        [ViewVariables(VVAccess.ReadOnly)]
+        public float SideLoadFraction => _sideLoad > 0 && _needsPower ? MathHelper.Clamp01((NetworkLoad.ReceivingPower - _mainLoad) / _sideLoad) : 1;
+
+        public float LastSideLoadFraction;
     }
 }

--- a/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.cs
+++ b/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.cs
@@ -358,8 +358,8 @@ public sealed partial class EmergencyShuttleSystem : EntitySystem
         if (result.ResultType == ShuttleDockResultType.NoDock)
         {
             _announcer.SendAnnouncement(
-                _announcer.GetAnnouncementId("ShuttleDock"),
-                "emergency-shuttle-docked",
+                _announcer.GetAnnouncementId("ShuttleNearby"),
+                "emergency-shuttle-nearby",
                 localeArgs:
                 [
                     ("time", $"{_consoleAccumulator:0}"),
@@ -372,8 +372,8 @@ public sealed partial class EmergencyShuttleSystem : EntitySystem
         else
         {
             _announcer.SendAnnouncement(
-                _announcer.GetAnnouncementId("ShuttleNearby"),
-                "emergency-shuttle-nearby",
+                _announcer.GetAnnouncementId("ShuttleDock"),
+                "emergency-shuttle-docked",
                 localeArgs:
                 [
                     ("time", $"{_consoleAccumulator:0}"),

--- a/Content.Server/_Lavaland/Shuttles/Systems/DockingShuttleSystem.cs
+++ b/Content.Server/_Lavaland/Shuttles/Systems/DockingShuttleSystem.cs
@@ -43,7 +43,7 @@ public sealed class DockingShuttleSystem : SharedDockingShuttleSystem
         var query = EntityQueryEnumerator<FTLDestinationComponent, MapComponent>();
         while (query.MoveNext(out var mapUid, out var dest, out var map))
         {
-            if (!dest.Enabled || _whitelist.IsWhitelistFailOrNull(dest.Whitelist, ent))
+            if (!dest.Enabled || _whitelist.IsWhitelistFail(dest.Whitelist, ent))
                 continue;
 
             AddDestinations(ent, map.MapId);

--- a/Content.Shared/CCVar/CCVars.Game.cs
+++ b/Content.Shared/CCVar/CCVars.Game.cs
@@ -380,7 +380,7 @@ public sealed partial class CCVars
     ///     If true, contraband severity can be viewed in the examine menu
     /// </summary>
     public static readonly CVarDef<bool> ContrabandExamine =
-        CVarDef.Create("game.contraband_examine", true, CVar.SERVER | CVar.REPLICATED);
+        CVarDef.Create("game.contraband_examine", false, CVar.SERVER | CVar.REPLICATED);
 
     /// <summary>
     /// Set to true to enable the dynamic hostname system.

--- a/Resources/Prototypes/Entities/Mobs/Player/observer.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/observer.yml
@@ -71,7 +71,9 @@
     - BypassInteractionRangeChecks
   - type: UniversalLanguageSpeaker # Ghosts should understand any language.
   - type: PointLight
+    netsync: false
     radius: 6
+    castShadows: false
     enabled: false
   - type: UserInterface
     interfaces:


### PR DESCRIPTION
This is a partial parity update to the Frostbite-Station repository using changes made to the master branch of the EE repository. It changes six files through five different commits. These changes include:

Updates to the APC Power Receiver Component to fix the behavior of APCs.
Updates to CCVars.Game.cs to disable examining the severity of contraband.
Updaters to Emergency and Docking Shuttle Systems to fix the announcements and spawning behaviour of the Emergency and Mining shuttles.

Updates to observer.yml to fix observer behaviour, including disabling shadows and fixing pointlights.